### PR TITLE
Require rspec feature for matcher definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.ruby-version
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/lib/act_like/rspec.rb
+++ b/lib/act_like/rspec.rb
@@ -1,3 +1,4 @@
+require 'rspec'
 require 'act_like/matcher'
 
 RSpec::Matchers.define :act_like do |expected|


### PR DESCRIPTION
This was hard to catch because in our own tests RSpec is already loaded.
However since we don't control the load order in code using this library,
it may not yet be loaded when the gem is required.